### PR TITLE
fix: 썸네일 백필 stale URL 레이스 및 intent 스킴 하이재킹 방지

### DIFF
--- a/app/src/main/java/com/hanto/hook/data/dao/HookDao.kt
+++ b/app/src/main/java/com/hanto/hook/data/dao/HookDao.kt
@@ -73,8 +73,15 @@ interface HookDao {
     @Query("UPDATE Hook SET isPinned = :isPinned WHERE hookId = :hookId")
     suspend fun updatePinStatus(hookId: String, isPinned: Boolean)
 
-    @Query("UPDATE Hook SET imageUrl = :imageUrl WHERE hookId = :hookId")
-    suspend fun updateHookImageUrl(hookId: String, imageUrl: String)
+    // url을 조건에 포함해, 백필이 끝나기 전에 사용자가 URL을 바꿔버린 경우
+    // 옛 URL의 썸네일이 새 URL의 레코드에 덮어써지는 것을 막는다.
+    @Query(
+        """
+        UPDATE Hook SET imageUrl = :imageUrl
+        WHERE hookId = :hookId AND (url = :url OR (url IS NULL AND :url IS NULL))
+        """
+    )
+    suspend fun updateHookImageUrl(hookId: String, url: String?, imageUrl: String)
 
     // ---------------------- 조회 ---------------------- //
     @Query("SELECT EXISTS(SELECT 1 FROM Hook LIMIT 1)")

--- a/app/src/main/java/com/hanto/hook/data/repository/HookRepositoryImpl.kt
+++ b/app/src/main/java/com/hanto/hook/data/repository/HookRepositoryImpl.kt
@@ -60,9 +60,9 @@ class HookRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun updateHookImage(hookId: String, imageUrl: String) {
+    override suspend fun updateHookImage(hookId: String, url: String?, imageUrl: String) {
         try {
-            hookDao.updateHookImageUrl(hookId, imageUrl)
+            hookDao.updateHookImageUrl(hookId, url, imageUrl)
         } catch (e: Exception) {
             Log.e(TAG, "Error updating hook image: $hookId", e)
             throw e

--- a/app/src/main/java/com/hanto/hook/domain/repository/HookRepository.kt
+++ b/app/src/main/java/com/hanto/hook/domain/repository/HookRepository.kt
@@ -22,7 +22,7 @@ interface HookRepository {
     // ---------------------- 쓰기 ---------------------- //
     suspend fun addHook(hook: Hook)
     suspend fun updateHook(hook: Hook)
-    suspend fun updateHookImage(hookId: String, imageUrl: String)
+    suspend fun updateHookImage(hookId: String, url: String?, imageUrl: String)
     suspend fun deleteHook(hookId: String)
     suspend fun setPinned(hookId: String, isPinned: Boolean)
     suspend fun renameTag(oldName: String, newName: String)

--- a/app/src/main/java/com/hanto/hook/domain/usecase/ThumbnailBackfiller.kt
+++ b/app/src/main/java/com/hanto/hook/domain/usecase/ThumbnailBackfiller.kt
@@ -27,7 +27,7 @@ class ThumbnailBackfiller @Inject constructor(
             try {
                 val imageUrl = metadataRepository.fetchOgImageUrl(url)
                 if (!imageUrl.isNullOrBlank()) {
-                    hookRepository.updateHookImage(hookId, imageUrl)
+                    hookRepository.updateHookImage(hookId, url, imageUrl)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to backfill thumbnail for $hookId", e)

--- a/app/src/main/java/com/hanto/hook/ui/view/activity/WebViewActivity.kt
+++ b/app/src/main/java/com/hanto/hook/ui/view/activity/WebViewActivity.kt
@@ -141,19 +141,19 @@ class WebViewActivity : BaseActivity() {
                 Intent(Intent.ACTION_VIEW, url.toUri())
             }
 
-            // intent:// 페이로드는 component/package/selector 필드를 임의로 지정할 수 있어,
-            // 신뢰할 수 없는 웹 콘텐츠가 우리 앱 자신의(비공개일 수도 있는) 컴포넌트를
-            // 조작된 extra와 함께 실행시키는 데 악용될 수 있다. 자기 자신을 대상으로 하거나
-            // selector로 다른 intent를 중첩 지정하는 경우는 차단한다.
-            val targetsSelf = intent.`package` == packageName ||
-                intent.component?.packageName == packageName ||
-                intent.selector?.`package` == packageName ||
-                intent.selector?.component?.packageName == packageName
-            if (targetsSelf) {
+            // intent:// 페이로드는 component/selector 필드를 임의로 지정할 수 있어, 신뢰할
+            // 수 없는 웹 콘텐츠가 (우리 앱을 포함해) 다른 앱의 exported이지만 비공개
+            // 화면을 조작된 extra와 함께 explicit하게 실행시키는 데 악용될 수 있다.
+            // 브라우저가 intent:// 링크를 처리하는 방식과 동일하게 explicit 지정을 모두
+            // 제거하고, CATEGORY_BROWSABLE을 선언한 액티비티만 암시적으로 해석되게 강제한다.
+            intent.component = null
+            intent.selector = null
+            intent.addCategory(Intent.CATEGORY_BROWSABLE)
+
+            if (intent.`package` == packageName) {
                 Log.w(TAG, "자체 앱을 대상으로 하는 intent 스킴 차단: $url")
                 return true
             }
-            intent.selector = null
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
 
             try {


### PR DESCRIPTION
Codex 리뷰 지적 반영:
- 백그라운드 썸네일 백필이 완료되기 전 URL이 변경된 경우, 옛 URL의 썸네일이 새 레코드에 덮어써지지 않도록 imageUrl 갱신 쿼리에 url 일치 조건 추가
- WebView의 intent:// 처리 시 explicit component/selector를 항상 제거하고 CATEGORY_BROWSABLE을 강제해, 신뢰할 수 없는 웹 콘텐츠가 다른 앱의 비공개 컴포넌트를 조작된 extra와 함께 실행시키지 못하도록 함